### PR TITLE
Support run time configuration of 'overrides' and 'except' via mfa

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ You can also specify to override or disable particular set of headers.
         ]
     end
 
+If you need to determine one of these at run time - for instance, in order to
+use a content security policy that allows resources from a location
+configured in environment variables - you can pass a "module, function,
+arguments" tuple; calling that function with those arguments must return a
+list as shown in the previous example.
+
+    pipeline :browser do
+      plug PlugSecex,
+        overrides: {MyModule, :overrides, [arg1, arg2]},
+        except: {MyModule, :exceptions, [arg3]}
+    end
+
 The supported headers and their values by default are:
 
     "x-content-type-options": "nosniff",

--- a/test/plug_secex_test.exs
+++ b/test/plug_secex_test.exs
@@ -11,6 +11,11 @@ defmodule PlugSecexTest do
     {:ok, %{conn: conn}}
   end
 
+  defmodule CustomConfig do
+    def overrides(headers), do: headers
+    def except(header_names), do: header_names
+  end
+
   test "Adds default security headers", %{conn: conn} do
     conn = PlugSecex.call(conn, PlugSecex.init([]))
     assert Enum.member?(conn.resp_headers, {"strict-transport-security", "max-age=31536000"})
@@ -22,8 +27,29 @@ defmodule PlugSecexTest do
     assert Enum.member?(conn.resp_headers, {"x-dns-prefetch-control", "on"})
   end
 
+  test "can determine overrides at run time using an mfa tuple", %{conn: conn} do
+    conn =
+      PlugSecex.call(
+        conn,
+        PlugSecex.init(overrides: {CustomConfig, :overrides, [["x-dns-prefetch-control": "on"]]})
+      )
+
+    assert Enum.member?(conn.resp_headers, {"x-dns-prefetch-control", "on"})
+  end
+
   test "except works appropriately", %{conn: conn} do
     conn = PlugSecex.call(conn, PlugSecex.init(except: ["x-dns-prefetch-control"]))
+    assert Enum.member?(conn.resp_headers, {"x-dns-prefetch-control", "on"}) === false
+    assert Enum.member?(conn.resp_headers, {"x-dns-prefetch-control", "off"}) === false
+  end
+
+  test "can determine 'except' at run time using an mfa tuple", %{conn: conn} do
+    conn =
+      PlugSecex.call(
+        conn,
+        PlugSecex.init(except: {CustomConfig, :except, [["x-dns-prefetch-control"]]})
+      )
+
     assert Enum.member?(conn.resp_headers, {"x-dns-prefetch-control", "on"}) === false
     assert Enum.member?(conn.resp_headers, {"x-dns-prefetch-control", "off"}) === false
   end
@@ -52,8 +78,51 @@ defmodule PlugSecexTest do
     assert Enum.member?(conn.resp_headers, {"xyz", "abc"})
   end
 
+  test "run time 'except' takes priority over overrides & they work together", %{conn: conn} do
+    conn =
+      PlugSecex.call(
+        conn,
+        PlugSecex.init(
+          overrides: {CustomConfig, :overrides, [["x-dns-prefetch-control": "on"]]},
+          except: {CustomConfig, :except, [["x-dns-prefetch-control"]]}
+        )
+      )
+
+    assert Enum.member?(conn.resp_headers, {"x-dns-prefetch-control", "on"}) === false
+    assert Enum.member?(conn.resp_headers, {"x-dns-prefetch-control", "off"}) === false
+
+    conn =
+      PlugSecex.call(
+        conn,
+        PlugSecex.init(
+          overrides: {CustomConfig, :overrides, [[xyz: "abc"]]},
+          except: {CustomConfig, :except, [["x-dns-prefetch-control"]]}
+        )
+      )
+
+    assert Enum.member?(conn.resp_headers, {"x-dns-prefetch-control", "on"}) === false
+    assert Enum.member?(conn.resp_headers, {"x-dns-prefetch-control", "off"}) === false
+    assert Enum.member?(conn.resp_headers, {"xyz", "abc"})
+  end
+
   test "handles invalid entries", %{conn: conn} do
     conn = PlugSecex.call(conn, PlugSecex.init(overrides: [abc: "on", xyz: nil]))
     assert Enum.member?(conn.resp_headers, {"xyz", nil}) === false
+  end
+
+  test "handles invalid options", %{conn: conn} do
+    assert_raise ArgumentError, fn ->
+      PlugSecex.call(
+        conn,
+        PlugSecex.init(overrides: "XSS 4ever")
+      )
+    end
+
+    assert_raise ArgumentError, fn ->
+      PlugSecex.call(
+        conn,
+        PlugSecex.init(except: "the really strict ones")
+      )
+    end
   end
 end


### PR DESCRIPTION
In case the list of header overrides or exceptions cannot be determined
at compile time, allow specifying a 'module function arguments' tuple by
which they can be determined at run time.